### PR TITLE
feat: Adicionar suporte ao Groq Chat com memória de longo prazo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,21 +23,32 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Integração com ferramentas (web_search, file operations) preservada
   - Metadados aprimorados incluindo ferramentas utilizadas e tipo de agente
 
+- **Suporte ao Groq Chat**: Novo provedor de IA adicionado ao sistema de chat
+  - Novo endpoint `/api/groq/chat` com memória de longo prazo
+  - Endpoints para gerenciar memória: GET e DELETE para `/api/groq/memory`
+  - Endpoint para listar modelos disponíveis: `/api/groq/models`
+  - Suporte a múltiplos modelos Groq (llama3-8b-8192, llama3-70b-8192, mixtral-8x7b-32768, gemma-7b-it)
+  - Integração completa com sistema de memória unificado
+
 ### Changed
 - Estrutura do projeto expandida com novos serviços de chat
 - **LangChain Agent Service**: Refatorado para usar memória persistente ao invés de memória em tempo de execução
   - Modelo atualizado para `gpt-4.1-mini` (compatibilidade com API)
   - Histórico de conversa limitado a 20 mensagens para otimização
   - Ordem cronológica corrigida para manter contexto adequado
+- **Sistema de Chat**: Expandido para suportar quatro provedores de IA (Gemini, OpenAI, Groq, LangChain)
+- **Endpoint de Health Check**: Atualizado para incluir todos os serviços disponíveis
 - Sistema de memória aprimorado para suportar múltiplos provedores de IA
 
 ### Technical Details
 - **Novos arquivos criados**:
   - `src/services/gemini_chat_service.py` - Serviço para integração com Google Gemini
   - `src/services/openai_chat_service.py` - Serviço para integração com OpenAI
+  - `src/services/groq_chat_service.py` - Serviço para integração com Groq
   - `src/routes/chat_routes.py` - Rotas para endpoints de chat
   - `test_gemini_chat.py` - Script de teste para validação do chat Gemini
   - `test_langchain_memory.py` - Script de teste para validação da memória do LangChain
+  - `test_groq_chat.py` - Script de teste para validação do chat Groq
   - `README_MEMORY_IMPLEMENTATION.md` - Documentação técnica da implementação
 
 - **Arquivos modificados**:
@@ -47,7 +58,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Dependências adicionadas**:
   - `google-generativeai` - SDK oficial do Google Gemini
-  - Configuração de variáveis de ambiente para `GEMINI_API_KEY`
+  - `groq` - SDK oficial do Groq
+  - Configuração de variáveis de ambiente para `GEMINI_API_KEY` e `GROQ_API_KEY`
 
 - **Funcionalidades implementadas**:
   - Recuperação automática do histórico de conversas para todos os provedores
@@ -55,8 +67,9 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Isolamento de sessões por `user_id` e `session_id`
   - Metadados de uso e estatísticas para cada interação
   - Tratamento de erros robusto em todos os serviços
-  - Suporte a diferentes modelos OpenAI via parâmetro opcional
+  - Suporte a diferentes modelos OpenAI e Groq via parâmetro opcional
   - Integração transparente do LangChain com ferramentas e memória persistente
+  - Endpoint para listar modelos disponíveis do Groq
 
 ### Notes
 - O sistema mantém compatibilidade com a estrutura existente do projeto
@@ -64,5 +77,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Cada sessão é isolada, permitindo múltiplas conversas simultâneas por usuário
 - O histórico é limitado às últimas 20 interações por sessão para otimização de performance
 - **LangChain Agent**: Mantém todas as funcionalidades originais (ferramentas, busca web, operações de arquivo) com memória persistente
-- Todos os três provedores (Gemini, OpenAI, LangChain) agora compartilham o mesmo sistema de memória unificado
+- **Groq**: Oferece modelos rápidos e eficientes, incluindo Llama 3 e Mixtral
+- Todos os quatro provedores (Gemini, OpenAI, Groq, LangChain) agora compartilham o mesmo sistema de memória unificado
+- Sistema escalável para adição de novos provedores de IA no futuro
 

--- a/src/routes/chat_routes.py
+++ b/src/routes/chat_routes.py
@@ -3,12 +3,14 @@ from flask_cors import cross_origin
 from datetime import datetime
 from src.services.gemini_chat_service import GeminiChatService
 from src.services.openai_chat_service import OpenAIChatService
+from src.services.groq_chat_service import GroqChatService
 
 chat_bp = Blueprint("chat", __name__)
 
 # Inicializar serviços
 gemini_service = GeminiChatService()
 openai_service = OpenAIChatService()
+groq_service = GroqChatService()
 
 @chat_bp.route("/gemini/chat", methods=["POST"])
 @cross_origin()
@@ -89,6 +91,47 @@ def openai_chat():
     except Exception as e:
         return jsonify({"error": f"Erro ao processar mensagem com OpenAI: {str(e)}"}), 500
 
+@chat_bp.route("/groq/chat", methods=["POST"])
+@cross_origin()
+def groq_chat():
+    """Endpoint para conversar com o Groq com memória de longo prazo"""
+    try:
+        data = request.get_json()
+        
+        if not data:
+            return jsonify({"error": "Dados não fornecidos"}), 400
+        
+        user_message = data.get("message")
+        user_id = data.get("user_id")
+        session_id = data.get("session_id")
+        model = data.get("model")  # Opcional: permite especificar o modelo
+        
+        if not user_message:
+            return jsonify({"error": "Mensagem é obrigatória"}), 400
+        
+        if not user_id:
+            return jsonify({"error": "user_id é obrigatório"}), 400
+        
+        # Processar mensagem com o Groq
+        response = groq_service.process_message(
+            user_message=user_message,
+            user_id=user_id,
+            session_id=session_id,
+            model=model
+        )
+        
+        return jsonify({
+            "success": True,
+            "response": response["message"],
+            "session_id": response["session_id"],
+            "model": response["model"],
+            "usage": response["usage"],
+            "timestamp": response["timestamp"]
+        }), 200
+        
+    except Exception as e:
+        return jsonify({"error": f"Erro ao processar mensagem com Groq: {str(e)}"}), 500
+
 @chat_bp.route("/gemini/memory", methods=["GET"])
 @cross_origin()
 def get_gemini_memory():
@@ -132,6 +175,28 @@ def get_openai_memory():
         
     except Exception as e:
         return jsonify({"error": f"Erro ao recuperar memória do OpenAI: {str(e)}"}), 500
+
+@chat_bp.route("/groq/memory", methods=["GET"])
+@cross_origin()
+def get_groq_memory():
+    """Recuperar memória do chat Groq para um usuário específico"""
+    try:
+        user_id = request.args.get("user_id")
+        session_id = request.args.get("session_id")
+        
+        if not user_id:
+            return jsonify({"error": "user_id é obrigatório"}), 400
+        
+        memory = groq_service.get_memory(user_id, session_id)
+        
+        return jsonify({
+            "success": True,
+            "memory": memory,
+            "timestamp": datetime.utcnow().isoformat()
+        }), 200
+        
+    except Exception as e:
+        return jsonify({"error": f"Erro ao recuperar memória do Groq: {str(e)}"}), 500
 
 @chat_bp.route("/gemini/memory", methods=["DELETE"])
 @cross_origin()
@@ -187,14 +252,57 @@ def clear_openai_memory():
     except Exception as e:
         return jsonify({"error": f"Erro ao limpar memória do OpenAI: {str(e)}"}), 500
 
+@chat_bp.route("/groq/memory", methods=["DELETE"])
+@cross_origin()
+def clear_groq_memory():
+    """Limpar memória do chat Groq para um usuário específico"""
+    try:
+        data = request.get_json()
+        
+        if not data:
+            return jsonify({"error": "Dados não fornecidos"}), 400
+        
+        user_id = data.get("user_id")
+        session_id = data.get("session_id")
+        
+        if not user_id:
+            return jsonify({"error": "user_id é obrigatório"}), 400
+        
+        groq_service.clear_memory(user_id, session_id)
+        
+        return jsonify({
+            "success": True,
+            "message": "Memória do Groq limpa com sucesso",
+            "timestamp": datetime.utcnow().isoformat()
+        }), 200
+        
+    except Exception as e:
+        return jsonify({"error": f"Erro ao limpar memória do Groq: {str(e)}"}), 500
+
 @chat_bp.route("/chat/health", methods=["GET"])
 @cross_origin()
 def health_check():
     """Endpoint de verificação de saúde dos chats"""
     return jsonify({
         "success": True,
-        "message": "Serviços de chat Gemini e OpenAI estão funcionando!",
-        "services": ["gemini", "openai"],
+        "message": "Serviços de chat Gemini, OpenAI e Groq estão funcionando!",
+        "services": ["gemini", "openai", "groq"],
         "timestamp": datetime.utcnow().isoformat()
     }), 200
+
+@chat_bp.route("/groq/models", methods=["GET"])
+@cross_origin()
+def get_groq_models():
+    """Endpoint para listar modelos disponíveis no Groq"""
+    try:
+        models = groq_service.get_available_models()
+        
+        return jsonify({
+            "success": True,
+            "models": models,
+            "timestamp": datetime.utcnow().isoformat()
+        }), 200
+        
+    except Exception as e:
+        return jsonify({"error": f"Erro ao recuperar modelos do Groq: {str(e)}"}), 500
 

--- a/src/services/groq_chat_service.py
+++ b/src/services/groq_chat_service.py
@@ -1,0 +1,141 @@
+import os
+import uuid
+from datetime import datetime
+from typing import Dict, List, Optional, Any
+from groq import Groq
+from src.services.memory_service import MemoryService
+
+
+class GroqChatService:
+    def __init__(self):
+        self.memory_service = MemoryService()
+        
+        # Configurar cliente Groq
+        api_key = os.getenv("GROQ_API_KEY")
+        if not api_key:
+            raise ValueError("GROQ_API_KEY não encontrada nas variáveis de ambiente")
+        
+        self.client = Groq(api_key=api_key)
+        self.model = "llama3-8b-8192"  # Modelo padrão do Groq
+        
+    def process_message(self, user_message: str, user_id: str, session_id: Optional[str] = None, model: Optional[str] = None) -> Dict[str, Any]:
+        """Processar mensagem do usuário com o Groq"""
+        try:
+            # Gerar session_id se não fornecido
+            if not session_id:
+                session_id = str(uuid.uuid4())
+            
+            # Usar modelo especificado ou padrão
+            selected_model = model or self.model
+            
+            # Recuperar histórico de conversa
+            history_data = self.memory_service.get_conversation_history(user_id, session_id, limit=20)
+            
+            # Construir mensagens para o Groq
+            messages = self._build_messages(history_data, user_message)
+            
+            # Gerar resposta com o Groq
+            response = self.client.chat.completions.create(
+                model=selected_model,
+                messages=messages,
+                temperature=0.7,
+                max_tokens=2000
+            )
+            
+            if not response.choices or not response.choices[0].message.content:
+                raise Exception("Groq não retornou uma resposta válida")
+            
+            assistant_response = response.choices[0].message.content
+            
+            # Salvar a conversa na memória
+            self.memory_service.save_message(
+                user_id=user_id,
+                session_id=session_id,
+                message=user_message,
+                response=assistant_response,
+                metadata={
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "model": selected_model,
+                    "provider": "groq",
+                    "usage": {
+                        "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+                        "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+                        "total_tokens": response.usage.total_tokens if response.usage else 0
+                    }
+                }
+            )
+            
+            return {
+                "message": assistant_response,
+                "session_id": session_id,
+                "timestamp": datetime.utcnow().isoformat(),
+                "model": selected_model,
+                "usage": {
+                    "prompt_tokens": response.usage.prompt_tokens if response.usage else 0,
+                    "completion_tokens": response.usage.completion_tokens if response.usage else 0,
+                    "total_tokens": response.usage.total_tokens if response.usage else 0
+                }
+            }
+            
+        except Exception as e:
+            raise Exception(f"Erro ao processar mensagem com Groq: {str(e)}")
+    
+    def _build_messages(self, history_data: List[Dict], current_message: str) -> List[Dict]:
+        """Construir mensagens para o Groq Chat API"""
+        messages = [
+            {
+                "role": "system",
+                "content": "Você é um assistente de IA útil e inteligente. Mantenha o contexto da conversa anterior e forneça respostas precisas e úteis."
+            }
+        ]
+        
+        # Adicionar histórico (em ordem cronológica)
+        if history_data:
+            # Reverter a ordem para mostrar do mais antigo para o mais recente
+            for item in reversed(history_data):
+                messages.append({
+                    "role": "user",
+                    "content": item['message']
+                })
+                messages.append({
+                    "role": "assistant",
+                    "content": item['response']
+                })
+        
+        # Adicionar mensagem atual
+        messages.append({
+            "role": "user",
+            "content": current_message
+        })
+        
+        return messages
+    
+    def get_memory(self, user_id: str, session_id: Optional[str] = None) -> List[Dict]:
+        """Recuperar memória do chat"""
+        try:
+            if session_id:
+                return self.memory_service.get_conversation_history(user_id, session_id)
+            else:
+                return []
+        except Exception as e:
+            raise Exception(f"Erro ao recuperar memória: {str(e)}")
+    
+    def clear_memory(self, user_id: str, session_id: Optional[str] = None) -> None:
+        """Limpar memória do chat"""
+        try:
+            if session_id:
+                self.memory_service.clear_conversation_history(user_id, session_id)
+            else:
+                self.memory_service.clear_user_memory(user_id)
+        except Exception as e:
+            raise Exception(f"Erro ao limpar memória: {str(e)}")
+    
+    def get_available_models(self) -> List[str]:
+        """Retornar lista de modelos disponíveis no Groq"""
+        return [
+            "llama3-8b-8192",
+            "llama3-70b-8192", 
+            "mixtral-8x7b-32768",
+            "gemma-7b-it"
+        ]
+

--- a/test_groq_chat.py
+++ b/test_groq_chat.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+import requests
+import json
+import uuid
+
+# Configurações
+BASE_URL = "http://localhost:5000/api"
+USER_ID = "test_groq_user_123"
+SESSION_ID = str(uuid.uuid4())
+
+def test_groq_chat():
+    """Testar o endpoint do chat Groq"""
+    print("=== Teste do Chat Groq ===")
+    
+    # Primeira mensagem
+    print("\n1. Enviando primeira mensagem...")
+    payload1 = {
+        "message": "Olá! Meu nome é Carlos e eu sou engenheiro de software. Como você está?",
+        "user_id": USER_ID,
+        "session_id": SESSION_ID
+    }
+    
+    response1 = requests.post(f"{BASE_URL}/groq/chat", json=payload1)
+    print(f"Status: {response1.status_code}")
+    if response1.status_code == 200:
+        result1 = response1.json()
+        print(f"Resposta: {result1.get('response', 'N/A')}")
+        print(f"Session ID: {result1.get('session_id', 'N/A')}")
+        print(f"Modelo: {result1.get('model', 'N/A')}")
+        print(f"Usage: {result1.get('usage', 'N/A')}")
+    else:
+        print(f"Erro: {response1.text}")
+    
+    # Segunda mensagem (testando memória)
+    print("\n2. Enviando segunda mensagem para testar memória...")
+    payload2 = {
+        "message": "Você lembra qual é o meu nome e minha profissão?",
+        "user_id": USER_ID,
+        "session_id": SESSION_ID
+    }
+    
+    response2 = requests.post(f"{BASE_URL}/groq/chat", json=payload2)
+    print(f"Status: {response2.status_code}")
+    if response2.status_code == 200:
+        result2 = response2.json()
+        print(f"Resposta: {result2.get('response', 'N/A')}")
+    else:
+        print(f"Erro: {response2.text}")
+    
+    # Terceira mensagem (testando modelo específico)
+    print("\n3. Enviando terceira mensagem com modelo específico...")
+    payload3 = {
+        "message": "Conte-me uma curiosidade sobre inteligência artificial",
+        "user_id": USER_ID,
+        "session_id": SESSION_ID,
+        "model": "mixtral-8x7b-32768"
+    }
+    
+    response3 = requests.post(f"{BASE_URL}/groq/chat", json=payload3)
+    print(f"Status: {response3.status_code}")
+    if response3.status_code == 200:
+        result3 = response3.json()
+        print(f"Resposta: {result3.get('response', 'N/A')}")
+        print(f"Modelo usado: {result3.get('model', 'N/A')}")
+    else:
+        print(f"Erro: {response3.text}")
+    
+    # Verificar memória
+    print("\n4. Verificando memória da conversa...")
+    memory_response = requests.get(f"{BASE_URL}/groq/memory", params={
+        "user_id": USER_ID,
+        "session_id": SESSION_ID
+    })
+    print(f"Status: {memory_response.status_code}")
+    if memory_response.status_code == 200:
+        memory_data = memory_response.json()
+        print(f"Número de mensagens na memória: {len(memory_data.get('memory', []))}")
+        for i, msg in enumerate(memory_data.get('memory', [])[:3]):  # Mostrar apenas as 3 primeiras
+            print(f"  Mensagem {i+1}: {msg.get('message', 'N/A')[:50]}...")
+            print(f"  Resposta {i+1}: {msg.get('response', 'N/A')[:50]}...")
+    else:
+        print(f"Erro ao recuperar memória: {memory_response.text}")
+
+def test_groq_models():
+    """Testar endpoint de modelos disponíveis"""
+    print("\n=== Teste de Modelos Groq ===")
+    
+    response = requests.get(f"{BASE_URL}/groq/models")
+    print(f"Status: {response.status_code}")
+    if response.status_code == 200:
+        result = response.json()
+        print(f"Modelos disponíveis: {result.get('models', [])}")
+    else:
+        print(f"Erro: {response.text}")
+
+def test_new_session():
+    """Testar nova sessão para verificar isolamento"""
+    print("\n=== Teste de Nova Sessão (Groq) ===")
+    
+    new_session_id = str(uuid.uuid4())
+    
+    payload = {
+        "message": "Você lembra qual é o meu nome e profissão?",
+        "user_id": USER_ID,
+        "session_id": new_session_id
+    }
+    
+    response = requests.post(f"{BASE_URL}/groq/chat", json=payload)
+    print(f"Status: {response.status_code}")
+    if response.status_code == 200:
+        result = response.json()
+        print(f"Resposta: {result.get('response', 'N/A')}")
+        print("(Esta resposta deve indicar que o agente não lembra, pois é uma nova sessão)")
+    else:
+        print(f"Erro: {response.text}")
+
+def test_health_check():
+    """Testar endpoint de saúde"""
+    print("\n=== Teste de Health Check ===")
+    
+    response = requests.get(f"{BASE_URL}/chat/health")
+    print(f"Status: {response.status_code}")
+    if response.status_code == 200:
+        result = response.json()
+        print(f"Mensagem: {result.get('message', 'N/A')}")
+        print(f"Serviços: {result.get('services', [])}")
+    else:
+        print(f"Erro: {response.text}")
+
+if __name__ == "__main__":
+    try:
+        test_health_check()
+        test_groq_models()
+        test_groq_chat()
+        test_new_session()
+        print("\n=== Testes do Groq concluídos ===")
+    except Exception as e:
+        print(f"Erro durante o teste: {e}")
+


### PR DESCRIPTION
- Implementar GroqChatService com integração ao MemoryService
- Adicionar endpoints /api/groq/chat, /api/groq/memory e /api/groq/models
- Suporte a múltiplos modelos Groq (llama3-8b-8192, llama3-70b-8192, mixtral-8x7b-32768, gemma-7b-it)
- Integração completa com sistema de memória unificado
- Atualizar health check para incluir Groq
- Criar testes específicos para validação do Groq
- Atualizar documentação e changelog com as mudanças
- Configurar GROQ_API_KEY no arquivo de ambiente